### PR TITLE
Fout opgelost. Groep 4 makkelijker gemaakt.

### DIFF
--- a/reken.html
+++ b/reken.html
@@ -30,7 +30,7 @@
                 <ul>
                     <li><a href="rekenen/groep4.php">Groep 4</a></li>
                     <li><a href="rekenen/groep5.php">Groep 5</a></li>
-                    <li><a href="rekenen/groep6.php">Groep 4</a></li>
+                    <li><a href="rekenen/groep6.php">Groep 6</a></li>
                 </ul>
             </section>
         </div>

--- a/rekenen/groep4.php
+++ b/rekenen/groep4.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <?php
-    $tafel_van = 3;
+    $tafel_van = 2;
 ?>
 
 <html>


### PR DESCRIPTION
Op ``reken.html`` stond eerst groep 4 als label voor groep 6. Dit is nu opgelost.

Groep 4 gebruikt nu de tafel van twee in plaats van de tafel van drie.